### PR TITLE
[WIP]ブランド登録修正

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -49,9 +49,10 @@ class ItemsController < ApplicationController
     if brand.present?
       @item.update(brand_id: brand.id)
     else
-    new_brand_id = Brand.new(name: params[:item])
-      if Brand.not.where(name: new_brand_id.name)
-      @item.update(brand_id: new_brand_id.id)
+    @new_brand = Brand.new(name: params[:item][:brand_id])
+      if Brand.where.not(name: @new_brand.name)
+      @new_brand.save if @brand.present?
+      @item.update(brand_id: @new_brand.id)
       else
       render :new
       flash[:alert] = 'ブランドの登録に失敗しました'

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -45,9 +45,18 @@ class ItemsController < ApplicationController
   def create
     @item = Item.new(item_params)
     @item.update(price: params[:price], profit_price: params[:profit_price], margin_price: params[:margin_price])
-    brand_id = Brand.find_by(name: params[:item][:brand_id])
-    brand_id = Brand.create(name: params[:item][:brand_id]) unless brand_id.present? && params[:item][:brand_id] == ""
-  
+    brand = Brand.find_by(name: params[:item][:brand_id])
+    if brand.present?
+      @item.update(brand_id: brand.id)
+    else
+    new_brand_id = Brand.new(name: params[:item])
+      if Brand.not.where(name: new_brand_id.name)
+      @item.update(brand_id: new_brand_id.id)
+      else
+      render :new
+      flash[:alert] = 'ブランドの登録に失敗しました'
+      end
+    end
     if @item.valid? && params[:item_images].present?
       @item.save
       params[:item_images][:image].each do |image|
@@ -55,8 +64,8 @@ class ItemsController < ApplicationController
       end
       redirect_to root_path, notice: '出品完了しました'
     else
-      flash[:alert] = '出品に失敗しました。必須項目を確認してください。'
       render :new
+      flash[:alert] = '出品に失敗しました。必須項目を確認してください。'
     end
   end
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -127,12 +127,12 @@ class ItemsController < ApplicationController
         end
       end
 
-      flash[:notice] = '編集が完了しました'
       redirect_to item_path(@item), data: {turbolinks: false}
+      flash[:notice] = '編集が完了しました'
 
     else
-      flash[:alert] = '未入力項目があります'
       redirect_back(fallback_location: root_path)
+      flash[:alert] = '未入力項目があります'
     end
 
   end


### PR DESCRIPTION
## WHAT
- 48行目、ブランドの検索。多重登録の可能性も考慮し、一番頭に見つけたidを取ってくるfind_byで十分
`brand = Brand.find_by(name: params[:item][:brand_id])`
- 49行目、ブランドが見つかった場合の分岐
- 51行目、ブランドが見つからなかった場合（つまり未登録なんで新規登録の処理）の分岐
- 53行目、しつこいくらいもう一度検索かけるw
- 54, 55行目、@new_brandが空でも登録されちゃうので後置で条件付与
- 58行目、もし登録失敗した場合の分岐

## As a result of above
ちゃんとDBに入ってきてくれました。
（ブランド既存の場合、ブランド新規登録の場合、ブランド登録なしの場合、３パターンで確認ずみ）
https://gyazo.com/ef7d4c09e78f0264f37ec1461930ea82
https://gyazo.com/997055cad10076d1ae2d2dec7718b855

## WHY
正常にブランド登録ができていなかったため