### PR TITLE
[WIP]新ガード節

### DIFF
--- a/app/assets/javascripts/item.js
+++ b/app/assets/javascripts/item.js
@@ -5,7 +5,7 @@
 // よろしくお願いいたします。
 
 
-$(function() {
+(document).on('turbolinks:load', ()=>  {
   $('.liked-items__sliders').slick({
     slidesToShow: 6,
     arrow: true,

--- a/app/assets/javascripts/item.js
+++ b/app/assets/javascripts/item.js
@@ -5,7 +5,7 @@
 // よろしくお願いいたします。
 
 
-(document).on('turbolinks:load', ()=>  {
+$(function() {
   $('.liked-items__sliders').slick({
     slidesToShow: 6,
     arrow: true,

--- a/app/assets/stylesheets/layouts/_flash.scss
+++ b/app/assets/stylesheets/layouts/_flash.scss
@@ -10,3 +10,13 @@
   background: #c0eec4;
   color: #76af7b
 }
+
+.flash-alert{
+  background: #f0cfe1;
+  color: #dd4062
+}
+
+.flash-notice{
+  background: #bae6ee;
+  color: #25aae7
+}

--- a/app/controllers/card_controller.rb
+++ b/app/controllers/card_controller.rb
@@ -1,49 +1,57 @@
 class CardController < ApplicationController
 
   require "payjp"
-  before_action :set_card, only: [:new, :delete, :edit]
+  before_action :card_presence, only: [:delete, :edit]
 
   def new
-    
-    redirect_to edit_card_path(current_user) unless @card.blank?
+    # あればEDitへ流す。なければpay    
+    redirect_to edit_card_path(current_user) if current_user.card_id.present?
   end
 
   def pay #payjpとCardのデータベース作成を実施します。
     Payjp.api_key = 'sk_test_a0029dc5466705b77c5d7bab'
-    if params['payjp-token'].blank?
-      redirect_to action: "new"
-    else
-      customer = Payjp::Customer.create(card: params['payjp-token'])
-      card = Card.new(user_id: current_user.id, customer_id: customer.id, card_id: customer.default_card)
-        if card.save
-          redirect_to edit_card_path(current_user)
-        else
-          redirect_to action: "pay"
-          notice[:delete] = "なんかちげー"
-        end
-    end
+    customer = Payjp::Customer.create(card: params['payjp-token'])
+    @card = Card.new(user_id: current_user.id, customer_id: customer.id, card_id: customer.default_card)
+      if @card.save
+        # Userにcard_idを入れます
+        current_user.update!(card_id: @card.id)
+        redirect_to root_path
+        flash[:delete] = "カードの登録に成功しました"
+        # redirect_to edit_card_path(current_user)
+      else
+        redirect_to action: "pay"
+        flash[:delete] = "カードの登録に失敗しました"
+      end
   end
 
   def delete #PayjpとCardデータベースを削除します
-    
     Payjp.api_key = 'sk_test_a0029dc5466705b77c5d7bab'
     customer = Payjp::Customer.retrieve(@card.customer_id)
     customer.delete
     @card.delete
     unless @card.blank?
-  end
+    end
+    #Itemのテーブルからも削除します
+    current_user.update(card_id: nil)
     redirect_to action: "new"
+    flash[:delete] = "カードの削除に成功しました"
   end
 
   def edit #Cardのデータpayjpに送り情報を取り出します
-    
     Payjp.api_key = 'sk_test_a0029dc5466705b77c5d7bab'
     customer = Payjp::Customer.retrieve(@card.customer_id)
     @default_card_information = customer.cards.retrieve(@card.card_id)
   end
 
-  def set_card
-    @card = Card.where(user_id: current_user.id).first
+
+  def card_presence
+    # Cardの登録がなされてない場合入れない入れなくする
+    if current_user.card_id.nil?
+      redirect_back(fallback_location: root_path)
+    else
+      # 入れたら登録ずみUserテーブルにあるcard_idとCardテーブルにあるidが同じカードを探して代入
+      @card = Card.find_by(id: current_user.card_id)
+    end
   end
-  
+
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,5 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, only: [:create, :new, :update, :edit]
+  before_action :authenticate_user!, except: [:index, :show, :show_buyer]
   before_action :set_item, only: [:update, :edit, :show, :destroy]
   before_action :set_category, only: [:new,:index,:show]
 
@@ -140,6 +140,23 @@ class ItemsController < ApplicationController
   end
 
   def show
+    if user_signed_in?
+      if current_user.id == @item.seller.id
+        render :show_own
+      else
+        render :show_buyer
+      end
+    elsif @item.buyer_id.present?
+      render :show_buyer
+    else
+      render :show_buyer
+    end
+  end
+
+  def show_own
+  end
+
+  def show_buyer
   end
 
 
@@ -147,10 +164,11 @@ class ItemsController < ApplicationController
   def destroy
     if user_signed_in?
       @item.destroy
-      flash[:delete] = "商品を削除しました"
       redirect_to root_path
+      flash[:delete] = "商品を削除しました"
     else
       redirect_back(fallback_location: item_path)
+      flash[:delete] = "削除に失敗しました"
     end
   end
 
@@ -196,6 +214,13 @@ class ItemsController < ApplicationController
 
   def set_category
     @parents = Category.all.order("id ASC").limit(13)
+  end
+
+  def ensure_identical_user
+    if @item.seller_id != current_user.id
+      redirect_to item_path
+      flash[:delete] = "不正アクセスは許しません！！！"
+    end
   end
 
 

--- a/app/controllers/purchase_controller.rb
+++ b/app/controllers/purchase_controller.rb
@@ -1,19 +1,23 @@
 class PurchaseController < ApplicationController
   require 'payjp'
   before_action :set_item, only: [:show, :pay, :done]
-  before_action :set_card, only: [:show, :pay, :done]
+  before_action :set_card, only: [:pay, :done]
+  before_action :anti_buy_my_own, only: [:pay, :show]
+  before_action :anti_buy_sold_item, only: [:pay, :show]
 
   def show
-    # @user = User.find(current_user.id)
-    if @card.blank?
+    if current_user.card_id.present?
       #登録された情報がない場合にカード登録画面に移動
       redirect_to controller: "card", action: "new"
-    else
+      @card = Card.where(buyer_id: current_user.id).first
       Payjp.api_key = 'sk_test_a0029dc5466705b77c5d7bab'
       #保管した顧客IDでpayjpから情報取得
       customer = Payjp::Customer.retrieve(@card.customer_id)
       #保管したカードIDでpayjpから情報取得、カード情報表示のためインスタンス変数に代入
       @default_card_information = customer.cards.retrieve(@card.card_id)
+    else
+      redirect_back(fallback_location: root_path)
+      flash[:notice] = 'まずはクレジットカードの登録をしてください'
     end
   end
 
@@ -46,4 +50,21 @@ class PurchaseController < ApplicationController
   def set_card
     @card = Card.where(buyer_id: current_user.id).first
   end
+
+  def anti_buy_my_own
+    @item = Item.find(params[:id])
+    if @item.seller_id == @current_user.id
+      redirect_to root_path
+      flash[:notice] = "自分で自分の買うとかないでしょ・・・"
+    end
+  end
+
+  def anti_buy_sold_item
+    @item = Item.find(params[:id])
+    if @item.buyer_id.present?
+      redirect_to root_path
+      flash[:notice] = "売り切れだっつーの"
+    end
+  end
+
 end

--- a/app/controllers/purchase_controller.rb
+++ b/app/controllers/purchase_controller.rb
@@ -6,16 +6,16 @@ class PurchaseController < ApplicationController
   before_action :anti_buy_sold_item, only: [:pay, :show]
 
   def show
+    # card_idの有無で分岐
     if current_user.card_id.present?
-      #登録された情報がない場合にカード登録画面に移動
-      redirect_to controller: "card", action: "new"
-      @card = Card.where(buyer_id: current_user.id).first
+      @card = Card.find_by(id: current_user.card_id)
       Payjp.api_key = 'sk_test_a0029dc5466705b77c5d7bab'
       #保管した顧客IDでpayjpから情報取得
       customer = Payjp::Customer.retrieve(@card.customer_id)
       #保管したカードIDでpayjpから情報取得、カード情報表示のためインスタンス変数に代入
       @default_card_information = customer.cards.retrieve(@card.card_id)
     else
+      # card_idがないつまり未登録。これで購入画面侵入を防いだ。
       redirect_back(fallback_location: root_path)
       flash[:notice] = 'まずはクレジットカードの登録をしてください'
     end
@@ -30,16 +30,18 @@ class PurchaseController < ApplicationController
   )
   redirect_to done_purchase_index_path(id:@item.id) #完了画面に移動
   end
+
+
   def done
-  # @user = User.find(current_user.id)
   customer = Payjp::Customer.retrieve(@card.customer_id)
   @default_card_information = customer.cards.retrieve(@card.card_id)
+  # ここでItemのbuyer_idをupdate
   @item_buyer= Item.find(params[:id])
   @item_buyer.update( buyer_id: current_user.id)
     if @item_buyer.save
     else
       redirect_to parchase_path
-      notice[:delete] = "購入できませんでした"
+      flash[:delete] = "購入できませんでした"
     end
   end
 
@@ -48,12 +50,12 @@ class PurchaseController < ApplicationController
   end
 
   def set_card
-    @card = Card.where(buyer_id: current_user.id).first
+    @card = Card.find_by(id: current_user.card_id)
   end
 
   def anti_buy_my_own
     @item = Item.find(params[:id])
-    if @item.seller_id == @current_user.id
+    if @item.seller_id == current_user.id
       redirect_to root_path
       flash[:notice] = "自分で自分の買うとかないでしょ・・・"
     end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -51,14 +51,17 @@ class Users::RegistrationsController < Devise::RegistrationsController
     Payjp.api_key = 'sk_test_a0029dc5466705b77c5d7bab'
     if params['payjp-token'].blank?
       redirect_to action: "new"
+      flash[:delete] = "データ更新に失敗しました"
     else
       customer = Payjp::Customer.create(card: params['payjp-token'])
       @card = Card.new(user_id: current_user.id, customer_id: customer.id, card_id: customer.default_card)
         if @card.save
+          # ここでUserのcard_idを更新
+          current_user.update(card_id: @card.id)
           redirect_to action: "complete"
         else
           redirect_to action: "register_credit_card"
-          notice[:delete] = "なんかちげー"
+          flash[:delete] = "クレジットカード登録に失敗しました"
         end
     end
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,10 +4,10 @@ class User < ApplicationRecord
   mount_uploader :avatar, ImageUploader
 
   # バリデーション
-  validates :nickname, :first_name, :last_name, :birth_year, :birth_month, :birth_day, presence: true
+  validates :nickname, :first_name, :last_name, :birth_year, :birth_month, :birth_day, presence: true, on: :sign_up
   validates :password, presence: true, length: { minimum: 7 }, 
             # 英数字のみ可
-            format: { with: /\A[a-z0-9]+\z/i, message: "は半角英数字７文字以上で入力してください" }
+            format: { with: /\A[a-z0-9]+\z/i, message: "は半角英数字７文字以上で入力してください" }, on: :sign_up
   validates :email, presence: true, 
             # 重複不可
             uniqueness: { case_sensitive: false }, 

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -1,194 +1,197 @@
--if user_signed_in?
-  =render "header"
--else
-  =render "header-unlogin"
-.item-detail-first-container
-  -# アイテム詳細ボックス
-  %section.item-box-container
-    %h1.item-name-box 
-      = @item.name
-    .item-main-box
-      -if @item.buyer_id.present? 
-        .items__sold
-          .items__sold__inner
-            SOLD
-      .box-photo
-        .box-photo__photo
-          - @item.images.each_with_index do |image, i|
-            = image_tag "#{image.src}"
+-# showを分岐させましたので、このファイルは読まれません。
+
+
+-# -if user_signed_in?
+-#   =render "header"
+-# -else
+-#   =render "header-unlogin"
+-# .item-detail-first-container
+-#   -# アイテム詳細ボックス
+-#   %section.item-box-container
+-#     %h1.item-name-box 
+-#       = @item.name
+-#     .item-main-box
+-#       -if @item.buyer_id.present? 
+-#         .items__sold
+-#           .items__sold__inner
+-#             SOLD
+-#       .box-photo
+-#         .box-photo__photo
+-#           - @item.images.each_with_index do |image, i|
+-#             = image_tag "#{image.src}"
         
-      %table.box__detail-table
-        %tbody
-          %tr
-            %th
-              出品者
-            %td
-              = link_to do
-                = @item.seller.nickname
-              %div
-                .user-ratings
-                  %i.icon-good
-                    = icon('fas', 'kiss-wink-heart')
-                  %span
-                  11
-                .user-ratings
-                  %i.icon-nomal
-                    = icon('fas', 'meh')
-                  %span
-                  14
-                .user-ratings
-                  %i.icon-bad 
-                    = icon('fas', 'dizzy')
-                  %span
-                  1
-          %tr
-            %th
-              カテゴリ
-            %td
-              = link_to do
-                = @parent.name
-              = link_to do
-                .sub-category
-                  = icon('fas', 'chevron-right')
-                  = @child.name
-              = link_to do
-                .sub-sub-category
-                  = icon('fas', 'chevron-right')
-                  = @grandchild.name
-          %tr
-            %th
-              ブランド
-            %td
-              = link_to do
-                コーチ
-          %tr
-            %th
-              商品の状態
-            %td
-              = @item.condition
-          %tr
-            %th
-              配送料の負担
-            %td
-              = @item.cover_postage
-          %tr
-            %th
-              配送の方法
-            %td
-              らくらくFmart便
-          %tr
-            %th
-              配送元地域
-            %td
-              = link_to do
-                = @item.prefectures
-          %tr
-            %th
-              発送日の目安
-            %td
-              = @item.shipping_date
-    .item-price-box
-      %span.item-price-box.bold
-        = "¥#{@item.price}"
-      %span.item-price-box.tax
-        (税込)
-      %span.item-price-box.fee
-        送料込み
-    .itms-buybox
-    -# -else
-    -#   = link_to 'ユーザー登録してね',root_path,class: 'item-buy-button '
-    - if user_signed_in? && current_user.id == @item.seller_id
-      = link_to "編集する", edit_item_path(@item.id),class:"item-sold-button"
-      .t_delete
-        この商品を削除する
-      .t_overlay
-      .t_modalWindow
-        .t_modalWindow__content
-          %p
-          %span 確認 
-          %p 削除すると二度と復活できません。
-          %p 削除する代わりに停止することもできます。
-          %br
-          %p 本当に削除しますか？
-        .t_modalWindow__buttons
-          .t_modalWindow__buttons__btn--cxl
-            キャンセル
-          .t_modalWindow__buttons__btn--cxl
-            = link_to "この商品を削除する",item_path(@item.id), method: :delete, class: "t_modalWindow__buttons__btn"
-    - elsif @item.buyer_id.present?  
-      = link_to '売り切れました','#',class: 'item-sold-button '
-    -else 
-      = link_to '購入画面に進む', purchase_path,class: 'item-buy-button '
-    .item-description-box
-      %p.item-description-box__inner 
-        = @item.description
-    .item-button-box
-      .item-button-box-left
-        .item-button-box-left__like.item-botton
-          = icon('far', 'heart')
-          いいね
-          ２５
-        .item-button-box-left__report.item-botton
-          = link_to do
-            = icon('far', 'flag')
-            %span 不適切な商品の報告
-      .item-button-box-right
-        = link_to do
-          = icon('fas', 'lock')
-          %span あんしん・あんぜんへの取り組み
+-#       %table.box__detail-table
+-#         %tbody
+-#           %tr
+-#             %th
+-#               出品者
+-#             %td
+-#               = link_to do
+-#                 = @item.seller.nickname
+-#               %div
+-#                 .user-ratings
+-#                   %i.icon-good
+-#                     = icon('fas', 'kiss-wink-heart')
+-#                   %span
+-#                   11
+-#                 .user-ratings
+-#                   %i.icon-nomal
+-#                     = icon('fas', 'meh')
+-#                   %span
+-#                   14
+-#                 .user-ratings
+-#                   %i.icon-bad 
+-#                     = icon('fas', 'dizzy')
+-#                   %span
+-#                   1
+-#           %tr
+-#             %th
+-#               カテゴリ
+-#             %td
+-#               = link_to do
+-#                 = @parent.name
+-#               = link_to do
+-#                 .sub-category
+-#                   = icon('fas', 'chevron-right')
+-#                   = @child.name
+-#               = link_to do
+-#                 .sub-sub-category
+-#                   = icon('fas', 'chevron-right')
+-#                   = @grandchild.name
+-#           %tr
+-#             %th
+-#               ブランド
+-#             %td
+-#               = link_to do
+-#                 コーチ
+-#           %tr
+-#             %th
+-#               商品の状態
+-#             %td
+-#               = @item.condition
+-#           %tr
+-#             %th
+-#               配送料の負担
+-#             %td
+-#               = @item.cover_postage
+-#           %tr
+-#             %th
+-#               配送の方法
+-#             %td
+-#               らくらくFmart便
+-#           %tr
+-#             %th
+-#               配送元地域
+-#             %td
+-#               = link_to do
+-#                 = @item.prefectures
+-#           %tr
+-#             %th
+-#               発送日の目安
+-#             %td
+-#               = @item.shipping_date
+-#     .item-price-box
+-#       %span.item-price-box.bold
+-#         = "¥#{@item.price}"
+-#       %span.item-price-box.tax
+-#         (税込)
+-#       %span.item-price-box.fee
+-#         送料込み
+-#     .itms-buybox
+-#     -# -else
+-#     -#   = link_to 'ユーザー登録してね',root_path,class: 'item-buy-button '
+-#     - if user_signed_in? && current_user.id == @item.seller_id
+-#       = link_to "編集する", edit_item_path(@item.id),class:"item-sold-button"
+-#       .t_delete
+-#         この商品を削除する
+-#       .t_overlay
+-#       .t_modalWindow
+-#         .t_modalWindow__content
+-#           %p
+-#           %span 確認 
+-#           %p 削除すると二度と復活できません。
+-#           %p 削除する代わりに停止することもできます。
+-#           %br
+-#           %p 本当に削除しますか？
+-#         .t_modalWindow__buttons
+-#           .t_modalWindow__buttons__btn--cxl
+-#             キャンセル
+-#           .t_modalWindow__buttons__btn--cxl
+-#             = link_to "この商品を削除する",item_path(@item.id), method: :delete, class: "t_modalWindow__buttons__btn"
+-#     - elsif @item.buyer_id.present?  
+-#       = link_to '売り切れました','#',class: 'item-sold-button '
+-#     -else 
+-#       = link_to '購入画面に進む', purchase_path,class: 'item-buy-button '
+-#     .item-description-box
+-#       %p.item-description-box__inner 
+-#         = @item.description
+-#     .item-button-box
+-#       .item-button-box-left
+-#         .item-button-box-left__like.item-botton
+-#           = icon('far', 'heart')
+-#           いいね
+-#           ２５
+-#         .item-button-box-left__report.item-botton
+-#           = link_to do
+-#             = icon('far', 'flag')
+-#             %span 不適切な商品の報告
+-#       .item-button-box-right
+-#         = link_to do
+-#           = icon('fas', 'lock')
+-#           %span あんしん・あんぜんへの取り組み
 
-  -# コメントボックス
-  .item-detail-comment
-    .comment-content
-      %ul.message-items
-        = render "detail/comment"
-    .comment-content
-      .message-form
-        = form_with model:@user,local: true do |form|
-          %p 相手のことを考え丁寧なコメントを心がけましょう。不快な言葉遣いなどは利用制限や退会処分となることがあります。
-          = form.text_area :nickname, class: "textarea-default"
-          = form.submit "コメントする", class: "submit-detail"
+-#   -# コメントボックス
+-#   .item-detail-comment
+-#     .comment-content
+-#       %ul.message-items
+-#         = render "detail/comment"
+-#     .comment-content
+-#       .message-form
+-#         = form_with model:@user,local: true do |form|
+-#           %p 相手のことを考え丁寧なコメントを心がけましょう。不快な言葉遣いなどは利用制限や退会処分となることがあります。
+-#           = form.text_area :nickname, class: "textarea-default"
+-#           = form.submit "コメントする", class: "submit-detail"
 
-  -# ナビバー
-  %ul.nav-item-link
-    .nav-item-link__previous
-      = link_to do
-        = icon('fas', 'chevron-left')
-        前の商品名
-    .nav-item-link__next
-      = link_to do
-        次の商品名
-        = icon('fas', 'chevron-right')
+-#   -# ナビバー
+-#   %ul.nav-item-link
+-#     .nav-item-link__previous
+-#       = link_to do
+-#         = icon('fas', 'chevron-left')
+-#         前の商品名
+-#     .nav-item-link__next
+-#       = link_to do
+-#         次の商品名
+-#         = icon('fas', 'chevron-right')
 
-  -# SNSロゴ
-  .sns-logo-container
-    %ul.sns-logo-box
-      %li
-        = link_to "#", class:"btn" do
-          = icon('fab', 'facebook', class:'fa-3x')
-      %li
-        = link_to "#", class:"btn" do
-          = icon('fab', 'twitter',class:'fa-3x')
-      %li.hidden-item
-        = link_to "#", class:"btn" do
-          = icon('fab', 'line',class:'fa-3x')
-      %li
-        = link_to "#", class:"btn" do
-          = icon('fab', 'pinterest',class:'fa-3x')
+-#   -# SNSロゴ
+-#   .sns-logo-container
+-#     %ul.sns-logo-box
+-#       %li
+-#         = link_to "#", class:"btn" do
+-#           = icon('fab', 'facebook', class:'fa-3x')
+-#       %li
+-#         = link_to "#", class:"btn" do
+-#           = icon('fab', 'twitter',class:'fa-3x')
+-#       %li.hidden-item
+-#         = link_to "#", class:"btn" do
+-#           = icon('fab', 'line',class:'fa-3x')
+-#       %li
+-#         = link_to "#", class:"btn" do
+-#           = icon('fab', 'pinterest',class:'fa-3x')
 
-  -# ユーザーのその他出品一覧
-  .other-items-in-user
-    %section
-      %h2.itembox-head
-        = link_to "#",class:"items-in-box" do
-          まりこさんのその他の出品
-        = render "detail/itembox"
-    %section
-      %h2.itembox-head
-        = link_to "#",class:"items-in-box" do
-          コーチのショルダーバッグ  その他の商品
-        = render "detail/itembox"
+-#   -# ユーザーのその他出品一覧
+-#   .other-items-in-user
+-#     %section
+-#       %h2.itembox-head
+-#         = link_to "#",class:"items-in-box" do
+-#           まりこさんのその他の出品
+-#         = render "detail/itembox"
+-#     %section
+-#       %h2.itembox-head
+-#         = link_to "#",class:"items-in-box" do
+-#           コーチのショルダーバッグ  その他の商品
+-#         = render "detail/itembox"
 
-  - breadcrumb :item,@item
-  = render "layouts/breadcrumbs"
-= render "footer"
+-#   - breadcrumb :item,@item
+-#   = render "layouts/breadcrumbs"
+-# = render "footer"

--- a/app/views/items/show_buyer.html.haml
+++ b/app/views/items/show_buyer.html.haml
@@ -1,0 +1,177 @@
+-if user_signed_in?
+  =render "header"
+-else
+  =render "header-unlogin"
+.item-detail-first-container
+  -# アイテム詳細ボックス
+  %section.item-box-container
+    %h1.item-name-box 
+      = @item.name
+    .item-main-box
+      -if @item.buyer_id.present? 
+        .items__sold
+          .items__sold__inner
+            SOLD
+      .box-photo
+        .box-photo__photo
+          - @item.images.each_with_index do |image, i|
+            = image_tag "#{image.src}"
+        
+      %table.box__detail-table
+        %tbody
+          %tr
+            %th
+              出品者
+            %td
+              = link_to do
+                = @item.seller.nickname
+              %div
+                .user-ratings
+                  %i.icon-good
+                    = icon('fas', 'kiss-wink-heart')
+                  %span
+                  11
+                .user-ratings
+                  %i.icon-nomal
+                    = icon('fas', 'meh')
+                  %span
+                  14
+                .user-ratings
+                  %i.icon-bad 
+                    = icon('fas', 'dizzy')
+                  %span
+                  1
+          %tr
+            %th
+              カテゴリ
+            %td
+              = link_to do
+                = @parent.name
+              = link_to do
+                .sub-category
+                  = icon('fas', 'chevron-right')
+                  = @child.name
+              = link_to do
+                .sub-sub-category
+                  = icon('fas', 'chevron-right')
+                  = @grandchild.name
+          %tr
+            %th
+              ブランド
+            %td
+              = link_to do
+                コーチ
+          %tr
+            %th
+              商品の状態
+            %td
+              = @item.condition
+          %tr
+            %th
+              配送料の負担
+            %td
+              = @item.cover_postage
+          %tr
+            %th
+              配送の方法
+            %td
+              らくらくFmart便
+          %tr
+            %th
+              配送元地域
+            %td
+              = link_to do
+                = @item.prefectures
+          %tr
+            %th
+              発送日の目安
+            %td
+              = @item.shipping_date
+    .item-price-box
+      %span.item-price-box.bold
+        = "¥#{@item.price}"
+      %span.item-price-box.tax
+        (税込)
+      %span.item-price-box.fee
+        送料込み
+    .itms-buybox
+    -if @item.buyer_id.present?
+        .item-sold-button
+          売り切れました
+    -elsif user_signed_in?
+      = link_to '購入画面に進む', purchase_path(@item.id),class: 'item-buy-button '
+    -else
+      = link_to '購入画面に進む', new_user_session_path ,class: 'item-buy-button '
+    .item-description-box
+      %p.item-description-box__inner 
+        = @item.description
+    .item-button-box
+      .item-button-box-left
+        .item-button-box-left__like.item-botton
+          = icon('far', 'heart')
+          いいね
+          ２５
+        .item-button-box-left__report.item-botton
+          = link_to do
+            = icon('far', 'flag')
+            %span 不適切な商品の報告
+      .item-button-box-right
+        = link_to do
+          = icon('fas', 'lock')
+          %span あんしん・あんぜんへの取り組み
+
+  -# コメントボックス
+  .item-detail-comment
+    .comment-content
+      %ul.message-items
+        = render "detail/comment"
+    .comment-content
+      .message-form
+        = form_with model:@user,local: true do |form|
+          %p 相手のことを考え丁寧なコメントを心がけましょう。不快な言葉遣いなどは利用制限や退会処分となることがあります。
+          = form.text_area :nickname, class: "textarea-default"
+          = form.submit "コメントする", class: "submit-detail"
+
+  -# ナビバー
+  %ul.nav-item-link
+    .nav-item-link__previous
+      = link_to do
+        = icon('fas', 'chevron-left')
+        前の商品名
+    .nav-item-link__next
+      = link_to do
+        次の商品名
+        = icon('fas', 'chevron-right')
+
+  -# SNSロゴ
+  .sns-logo-container
+    %ul.sns-logo-box
+      %li
+        = link_to "#", class:"btn" do
+          = icon('fab', 'facebook', class:'fa-3x')
+      %li
+        = link_to "#", class:"btn" do
+          = icon('fab', 'twitter',class:'fa-3x')
+      %li.hidden-item
+        = link_to "#", class:"btn" do
+          = icon('fab', 'line',class:'fa-3x')
+      %li
+        = link_to "#", class:"btn" do
+          = icon('fab', 'pinterest',class:'fa-3x')
+
+  -# ユーザーのその他出品一覧
+  .other-items-in-user
+    %section
+      %h2.itembox-head
+        = link_to "#",class:"items-in-box" do
+          まりこさんのその他の出品
+        = render "detail/itembox"
+    %section
+      %h2.itembox-head
+        = link_to "#",class:"items-in-box" do
+          コーチのショルダーバッグ  その他の商品
+        = render "detail/itembox"
+
+  - breadcrumb :item,@item
+  = render "layouts/breadcrumbs"
+= render "footer"

--- a/app/views/items/show_buyer.html.haml
+++ b/app/views/items/show_buyer.html.haml
@@ -96,8 +96,8 @@
         送料込み
     .itms-buybox
     -if @item.buyer_id.present?
-        .item-sold-button
-          売り切れました
+      .item-sold-button
+        売り切れました
     -elsif user_signed_in?
       = link_to '購入画面に進む', purchase_path(@item.id),class: 'item-buy-button '
     -else

--- a/app/views/items/show_own.html.haml
+++ b/app/views/items/show_own.html.haml
@@ -95,10 +95,8 @@
       %span.item-price-box.fee
         送料込み
     .itms-buybox
-    -# -else
-    -#   = link_to 'ユーザー登録してね',root_path,class: 'item-buy-button '
     - if user_signed_in? && current_user.id == @item.seller_id
-      = link_to "編集する", edit_item_path(@item.id),class:"item-sold-button"
+      = link_to "編集する", edit_item_path(@item.id),class:"item-buy-button "
       .t_delete
         この商品を削除する
       .t_overlay
@@ -115,10 +113,8 @@
             キャンセル
           .t_modalWindow__buttons__btn--cxl
             = link_to "この商品を削除する",item_path(@item.id), method: :delete, class: "t_modalWindow__buttons__btn"
-    - elsif @item.buyer_id.present?  
+    - else @item.buyer_id.present?  
       = link_to '売り切れました','#',class: 'item-sold-button '
-    -else 
-      = link_to '購入画面に進む', purchase_path,class: 'item-buy-button '
     .item-description-box
       %p.item-description-box__inner 
         = @item.description

--- a/app/views/items/show_own.html.haml
+++ b/app/views/items/show_own.html.haml
@@ -1,0 +1,194 @@
+-if user_signed_in?
+  =render "header"
+-else
+  =render "header-unlogin"
+.item-detail-first-container
+  -# アイテム詳細ボックス
+  %section.item-box-container
+    %h1.item-name-box 
+      = @item.name
+    .item-main-box
+      -if @item.buyer_id.present? 
+        .items__sold
+          .items__sold__inner
+            SOLD
+      .box-photo
+        .box-photo__photo
+          - @item.images.each_with_index do |image, i|
+            = image_tag "#{image.src}"
+        
+      %table.box__detail-table
+        %tbody
+          %tr
+            %th
+              出品者
+            %td
+              = link_to do
+                = @item.seller.nickname
+              %div
+                .user-ratings
+                  %i.icon-good
+                    = icon('fas', 'kiss-wink-heart')
+                  %span
+                  11
+                .user-ratings
+                  %i.icon-nomal
+                    = icon('fas', 'meh')
+                  %span
+                  14
+                .user-ratings
+                  %i.icon-bad 
+                    = icon('fas', 'dizzy')
+                  %span
+                  1
+          %tr
+            %th
+              カテゴリ
+            %td
+              = link_to do
+                = @parent.name
+              = link_to do
+                .sub-category
+                  = icon('fas', 'chevron-right')
+                  = @child.name
+              = link_to do
+                .sub-sub-category
+                  = icon('fas', 'chevron-right')
+                  = @grandchild.name
+          %tr
+            %th
+              ブランド
+            %td
+              = link_to do
+                コーチ
+          %tr
+            %th
+              商品の状態
+            %td
+              = @item.condition
+          %tr
+            %th
+              配送料の負担
+            %td
+              = @item.cover_postage
+          %tr
+            %th
+              配送の方法
+            %td
+              らくらくFmart便
+          %tr
+            %th
+              配送元地域
+            %td
+              = link_to do
+                = @item.prefectures
+          %tr
+            %th
+              発送日の目安
+            %td
+              = @item.shipping_date
+    .item-price-box
+      %span.item-price-box.bold
+        = "¥#{@item.price}"
+      %span.item-price-box.tax
+        (税込)
+      %span.item-price-box.fee
+        送料込み
+    .itms-buybox
+    -# -else
+    -#   = link_to 'ユーザー登録してね',root_path,class: 'item-buy-button '
+    - if user_signed_in? && current_user.id == @item.seller_id
+      = link_to "編集する", edit_item_path(@item.id),class:"item-sold-button"
+      .t_delete
+        この商品を削除する
+      .t_overlay
+      .t_modalWindow
+        .t_modalWindow__content
+          %p
+          %span 確認 
+          %p 削除すると二度と復活できません。
+          %p 削除する代わりに停止することもできます。
+          %br
+          %p 本当に削除しますか？
+        .t_modalWindow__buttons
+          .t_modalWindow__buttons__btn--cxl
+            キャンセル
+          .t_modalWindow__buttons__btn--cxl
+            = link_to "この商品を削除する",item_path(@item.id), method: :delete, class: "t_modalWindow__buttons__btn"
+    - elsif @item.buyer_id.present?  
+      = link_to '売り切れました','#',class: 'item-sold-button '
+    -else 
+      = link_to '購入画面に進む', purchase_path,class: 'item-buy-button '
+    .item-description-box
+      %p.item-description-box__inner 
+        = @item.description
+    .item-button-box
+      .item-button-box-left
+        .item-button-box-left__like.item-botton
+          = icon('far', 'heart')
+          いいね
+          ２５
+        .item-button-box-left__report.item-botton
+          = link_to do
+            = icon('far', 'flag')
+            %span 不適切な商品の報告
+      .item-button-box-right
+        = link_to do
+          = icon('fas', 'lock')
+          %span あんしん・あんぜんへの取り組み
+
+  -# コメントボックス
+  .item-detail-comment
+    .comment-content
+      %ul.message-items
+        = render "detail/comment"
+    .comment-content
+      .message-form
+        = form_with model:@user,local: true do |form|
+          %p 相手のことを考え丁寧なコメントを心がけましょう。不快な言葉遣いなどは利用制限や退会処分となることがあります。
+          = form.text_area :nickname, class: "textarea-default"
+          = form.submit "コメントする", class: "submit-detail"
+
+  -# ナビバー
+  %ul.nav-item-link
+    .nav-item-link__previous
+      = link_to do
+        = icon('fas', 'chevron-left')
+        前の商品名
+    .nav-item-link__next
+      = link_to do
+        次の商品名
+        = icon('fas', 'chevron-right')
+
+  -# SNSロゴ
+  .sns-logo-container
+    %ul.sns-logo-box
+      %li
+        = link_to "#", class:"btn" do
+          = icon('fab', 'facebook', class:'fa-3x')
+      %li
+        = link_to "#", class:"btn" do
+          = icon('fab', 'twitter',class:'fa-3x')
+      %li.hidden-item
+        = link_to "#", class:"btn" do
+          = icon('fab', 'line',class:'fa-3x')
+      %li
+        = link_to "#", class:"btn" do
+          = icon('fab', 'pinterest',class:'fa-3x')
+
+  -# ユーザーのその他出品一覧
+  .other-items-in-user
+    %section
+      %h2.itembox-head
+        = link_to "#",class:"items-in-box" do
+          まりこさんのその他の出品
+        = render "detail/itembox"
+    %section
+      %h2.itembox-head
+        = link_to "#",class:"items-in-box" do
+          コーチのショルダーバッグ  その他の商品
+        = render "detail/itembox"
+
+  - breadcrumb :item,@item
+  = render "layouts/breadcrumbs"
+= render "footer"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -59,6 +59,8 @@ end
       get 'category_children', defaults: { format: 'json' }
       get 'category_grandchildren', defaults: { format: 'json' }
       get 'image', defaults: { format: 'json' }
+      get 'show_own'
+      get 'show_buyer'
     end
     member do
       get 'category_children', defaults: { format: 'json' }

--- a/db/migrate/20200310163425_add_card_id_to_users.rb
+++ b/db/migrate/20200310163425_add_card_id_to_users.rb
@@ -1,0 +1,5 @@
+class AddCardIdToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_reference :users, :card, index: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_09_021016) do
+ActiveRecord::Schema.define(version: 2020_03_10_163425) do
 
   create_table "addresses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "postal_code", null: false
@@ -98,6 +98,8 @@ ActiveRecord::Schema.define(version: 2020_03_09_021016) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "last_name", null: false
+    t.bigint "card_id"
+    t.index ["card_id"], name: "index_users_on_card_id"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end


### PR DESCRIPTION
## Guard
ログインしていないユーザーが商品一覧・商品詳細以外のページへ行こうとしたらログインページへリダイレクトさせる
=>before_action :authenticate_user!, except: [:index, :show, :show_buyer]
自身が出品した商品は「購入画面へ進む」ボタンを押せなくなっている
=> show.html.hamlを削除し、購入者用としてのviewと出品者用としてのviewをcontrollerから分岐させた。showアクションのif current_user.id == @item.seller.idの部分。
自身が出品した商品の購入画面へURLを直打ちしても飛べないようになっている
=> 下をbefore_actionに入れた。
anti_buy_my_own
自身が出品した商品は、支払いを作成するアクション(Payjp::Charge.createをするアクション)を動かせないようになっている
=> 下をbefore_actionに入れた。
anti_buy_my_own
一度購入された商品は「購入画面へ進む」ボタンを押せなくなっている
=> show.html.hamlを削除し、購入者用としてのviewと出品者用としてのviewをcontrollerから分岐させた。showアクションのelsif @item.buyer_id.present?` の部分
一度購入された商品の購入画面へURLを直打ちしても飛べなくなっている
=> 下をbefore_actionに入れた。
anti_buy_sold_item
一度購入された商品は、支払いを作成するアクション(Payjp::Charge.createをするアクション)を動かせないようになっている
=> 下をbefore_actionに入れた。
anti_buy_sold_item
他人の商品は「編集する」ボタンを押せなくなっている
=> show.html.hamlを削除し、購入者用としてのviewと出品者用としてのviewをcontrollerから分岐させた。コントローラーでrender :show_ownできるのは、current_user.id == @item.seller.id のみと担保させた。
他人の商品の編集画面へURLを直打ちしても飛べないようになっている
=> 下をbefore_actionに入れた。
ensure_identical_user
他人の商品の更新アクション(products#update等)を動かせないようになっている(コントローラで対策する)
=> 下をbefore_actionに入れた。
ensure_identical_user
他人の商品の削除アクション(products#destroy等)を動かせないようになっている(コントローラで対策する)
=> 下をbefore_actionに入れた。
ensure_identical_user
商品出品時に画像無しでは出品できないようになっている
=> validates :src, :item_id, presence: true

## Credit_Cardの分岐
- User に各自card_idを持たせ、card_idのないユーザーは購入できないよう分岐した。
- Flashの可視化