### PR TITLE
商品出品バリデーション

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -14,7 +14,7 @@ class Item < ApplicationRecord
   validates :description, length: { in: 1..1000}, presence: true
   validates :price, numericality: { only_integer: true, greater_than: 299, less_than: 9999999}
   validates :category_id, numericality: { only_integer: true }
-
+  validates :src, presence: true
   include AASM
 
   aasm do


### PR DESCRIPTION
＃WHAT
商品出品時に画像なく保存しようとしたらエラーでるがDBに保存されていたので、正しくバリデーションをかけて画像ない出品はDBに保存されないようにした
＃WHY
そうじゃないとプログラム全体にエラー起きるから